### PR TITLE
fix: correct param typedef in update presence function

### DIFF
--- a/lua/cord/utils.lua
+++ b/lua/cord/utils.lua
@@ -72,7 +72,7 @@ local function init_discord(ffi)
       const char* icon,
       const char* tooltip,
       int asset_type,
-      const InitArgs* args
+      const PresenceArgs* args
     );
     void clear_presence();
     void disconnect();


### PR DESCRIPTION
Fix error message due to wrong parameter type in cdef for `update_presence_with_assets` function.

<img width="1290" alt="Screenshot 2024-05-02 at 12 48 40" src="https://github.com/vyfor/cord.nvim/assets/42694704/3fa864fe-1660-44d1-8292-28aabef71ce0">
