### PR TITLE
feat: add Nix Flakes and Direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 /cord
 /cord.*
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,46 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1721379653,
+        "narHash": "sha256-8MUgifkJ7lkZs3u99UDZMB4kbOxvMEXQZ31FO3SopZ0=",
+        "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+        "revCount": 655136,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.655136%2Brev-1d9c2c9b3e71b9ee663d11c5d298727dace8d374/0190cd4f-c0eb-72cb-834b-ac854aa282dc/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1721355572,
+        "narHash": "sha256-I4TQ2guV9jTmZsXeWt5HMojcaqNZHII4zu0xIKZEovM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d5bc7b1b21cf937fb8ff108ae006f6776bdb163d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "A Nix-flake-based Rust development environment";
+
+  inputs = {
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    rust-overlay,
+  }: let
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    forEachSupportedSystem = f:
+      nixpkgs.lib.genAttrs supportedSystems (system:
+        f {
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [rust-overlay.overlays.default self.overlays.default];
+          };
+        });
+  in {
+    overlays.default = final: prev: {
+      rustToolchain = let
+        rust = prev.rust-bin;
+      in
+        if builtins.pathExists ./rust-toolchain.toml
+        then rust.fromRustupToolchainFile ./rust-toolchain.toml
+        else if builtins.pathExists ./rust-toolchain
+        then rust.fromRustupToolchainFile ./rust-toolchain
+        else
+          rust.stable.latest.default.override {
+            extensions = ["rust-src" "rustfmt"];
+          };
+    };
+
+    devShells = forEachSupportedSystem ({pkgs}: {
+      default = pkgs.mkShell {
+        packages = with pkgs; [
+          rustToolchain
+          openssl
+          pkg-config
+          cargo-deny
+          cargo-edit
+          cargo-watch
+          rust-analyzer
+        ];
+
+        env = {
+          # Required by rust-analyzer
+          RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
+        };
+      };
+    });
+  };
+}


### PR DESCRIPTION
This pull request introduces Nix Flakes and Direnv, aiming to enhance the reproducibility of developer environments and streamline the management of dependencies.

## Benefits of Nix Flakes
- **Reproducibility:** Flakes ensure that your development environments are consistent and reproducible across different machines and over time. By specifying dependencies and configurations in a flake, we can avoid "it works on my machine" issues.
- **Version Pinning:** Flakes allow us to pin specific versions of packages, reducing the risk of unexpected changes due to upstream updates.
- **Isolation:** Using Flakes, we can avoid polluting the global environment with project-specific dependencies, keeping systems cleaner and more manageable.

## Benefits of Direnv
- **Automated Environment Setup:** Direnv automatically activates the Nix environment defined in the flake when you enter the project directory, making it effortless to start working on the project.
- **Seamless Integration:** Direnv integrates smoothly with your shell, providing a seamless experience without requiring manual intervention.

## Setup Instructions
1. **Install Nix:** Ensure you have Nix installed on your system. If not, follow the installation instructions at [Nix Installation Guide](https://nixos.org/download.html).
2. **Enable Flakes:** Flakes are an experimental feature. To enable them, add the following lines to your Nix configuration file (`~/.config/nix/nix.conf`):
```nix
experimental-features = nix-command flakes
```
3. **Install Direnv:** Install Direnv by following the instructions at [Direnv Installation Guide](https://direnv.net/docs/installation.html).
4. **Configure Direnv:** Hook Direnv into your shell by following the instructions at [Direnv Hook](https://direnv.net/docs/hook.html).

## Usage
- Upon entering the project directory, Direnv will automatically load the Nix environment specified in the flake.
- To update the environment, run `nix flake update` in the project root.