### PR TITLE
feat: add `fern` as a file browser 🍜 

### DIFF
--- a/src/mappings/file_browser.rs
+++ b/src/mappings/file_browser.rs
@@ -3,6 +3,7 @@ pub fn get(filetype: &str) -> Option<(&str, &str)> {
         "netrw" => ("default", "Netrw"),
         "TelescopePrompt" => ("telescope", "Telescope"),
         "dirvish" => ("default", "Dirvish"),
+        "fern" => ("default", "Fern"),
         "oil" => ("default", "Oil"),
         "neo-tree" => ("default", "Neo-Tree"),
         "NvimTree" => ("default", "nvim-tree"),


### PR DESCRIPTION
Hi!
Added [`Fern`](https://github.com/lambdalisue/vim-fern) as a file browser 🍜 
