### PR TITLE
Potential Fix for the build error mentioned in #117

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/build
+++ b/build
@@ -5,5 +5,5 @@ if command -v nix >/dev/null 2>&1; then
     nix develop --command sh -c 'rustc --crate-type=cdylib -C opt-level=3 -C panic=abort -C lto=fat -o cord src/lib.rs'
 else
     echo "Nix not found. Make sure Rust and dependencies are installed manually." 
-rustc --crate-type=cdylib -C opt-level=3 -C panic=abort -C lto=fat -o cord src/lib.rs
-
+    rustc --crate-type=cdylib -C opt-level=3 -C panic=abort -C lto=fat -o cord src/lib.rs
+fi

--- a/build
+++ b/build
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-direnv allow
-
+if command -v nix >/dev/null 2>&1; then
+    echo "Nix found, using nix develop..." 
+    nix develop --command sh -c 'rustc --crate-type=cdylib -C opt-level=3 -C panic=abort -C lto=fat -o cord src/lib.rs'
+else
+    echo "Nix not found. Make sure Rust and dependencies are installed manually." 
 rustc --crate-type=cdylib -C opt-level=3 -C panic=abort -C lto=fat -o cord src/lib.rs
 

--- a/build
+++ b/build
@@ -1,10 +1,6 @@
 #!/bin/sh
 
-if command -v nix >/dev/null 2>&1; then
-    echo "Nix found, using nix develop..." 
-    nix develop --command sh -c 'rustc --crate-type=cdylib -C opt-level=3 -C panic=abort -C lto=fat -o cord src/lib.rs'
-else
-    echo "Nix not found. Make sure Rust and dependencies are installed manually." 
-    rustc --crate-type=cdylib -C opt-level=3 -C panic=abort -C lto=fat -o cord src/lib.rs
+direnv allow
 
-fi
+rustc --crate-type=cdylib -C opt-level=3 -C panic=abort -C lto=fat -o cord src/lib.rs
+

--- a/build
+++ b/build
@@ -1,13 +1,10 @@
 #!/bin/sh
 
-# Check if Nix is installed
 if command -v nix >/dev/null 2>&1; then
-    echo "Nix found, using nix develop..."
-    nix develop
+    echo "Nix found, using nix develop..." 
+    nix develop --command sh -c 'rustc --crate-type=cdylib -C opt-level=3 -C panic=abort -C lto=fat -o cord src/lib.rs'
 else
-    echo "Nix not found. Make sure Rust and dependencies are installed manually."
+    echo "Nix not found. Make sure Rust and dependencies are installed manually." 
+    rustc --crate-type=cdylib -C opt-level=3 -C panic=abort -C lto=fat -o cord src/lib.rs
+
 fi
-
-# Compile the Rust project
-rustc --crate-type=cdylib -C opt-level=3 -C panic=abort -C lto=fat -o cord src/lib.rs
-

--- a/build
+++ b/build
@@ -1,3 +1,13 @@
 #!/bin/sh
 
+# Check if Nix is installed
+if command -v nix >/dev/null 2>&1; then
+    echo "Nix found, using nix develop..."
+    nix develop
+else
+    echo "Nix not found. Make sure Rust and dependencies are installed manually."
+fi
+
+# Compile the Rust project
 rustc --crate-type=cdylib -C opt-level=3 -C panic=abort -C lto=fat -o cord src/lib.rs
+


### PR DESCRIPTION
This PR offers a potential fix for the problem mentioned in #117 where the build fails because `direnv allow` needs to be run before `./build` file could be run.

This was done by using the `nix develop` command that loads the flake directly without the use or a .envrc file.
The if statement is used to determine if the user uses nix