### PR TITLE
feat(lua): add support for BSD

### DIFF
--- a/lua/cord/utils.lua
+++ b/lua/cord/utils.lua
@@ -23,7 +23,7 @@ local function init_discord(ffi)
   local os_name = vim.loop.os_uname().sysname
   if os_name:find('Windows', 1, true) == 1 then -- starts with 'Windows'
     cord_file = '/cord.dll'
-  elseif os_name == 'Linux' then
+  elseif os_name == 'Linux' or os_name:match("BSD$") then
     cord_file = '/cord.so'
   elseif os_name == 'Darwin' then
     cord_file = '/cord.dylib'


### PR DESCRIPTION
Hi:

I roughly read through the code base, and found out it's using neovim's `vim` lua interface to aggregate data. Since rust and lua are both available on major BSDs ([1](https://doc.rust-lang.org/nightly/rustc/platform-support.html) , [2](https://neovim.io/doc/user/support.html)), it should work theoretically.

I added a switch that add checks for BSD, and use the compiled `cord.so` for FFI.

Here are my test results using [FreeBSD14](https://www.freebsd.org/releases/14.1R/announce/) and [LegCord](https://legcord.app/):

![idle](https://github.com/user-attachments/assets/b5d71637-9f98-4042-93ba-eeacfbf0b348)
![edit](https://github.com/user-attachments/assets/d4ee445b-c295-4717-8957-64b3349991cb)
![commit](https://github.com/user-attachments/assets/0898cfe4-a57e-404b-9396-6dd3744df28e)
![browsing](https://github.com/user-attachments/assets/f5f72cc3-6808-4627-8263-caff1ea688c7)

Before it shows unsupported platform:

![image](https://github.com/user-attachments/assets/c4ff6a9c-03ac-410c-8c6c-3c9a064262c1)
