### PR TITLE
fix: fix autocompletion for subcommand-less commands

### DIFF
--- a/lua/cord/api/command.lua
+++ b/lua/cord/api/command.lua
@@ -215,7 +215,7 @@ end
 
 M.get_subcommands = function(cmd)
   local command = M.commands[cmd]
-  if not command or not command.subcommands then return {} end
+  if type(command) ~= 'table' or not command.subcommands then return {} end
 
   local subcmds = {}
   for subcmd, _ in pairs(command.subcommands) do


### PR DESCRIPTION
Otherwise, seems to cause an error with nvim-cmp.