### PR TITLE
fix(usercmd): completion for partial command

### DIFF
--- a/plugin/cord.vim
+++ b/plugin/cord.vim
@@ -14,7 +14,10 @@ function! CordCompleteList(ArgLead, CmdLine, CmdPos)
         return filter(l:features, 'stridx(v:val, a:ArgLead) == 0')
     endif
     
-    if len(l:args) == 2 || (len(l:args) == 3 && !l:starting_new_arg)
+    if len(l:args) == 2 && !l:starting_new_arg
+        let l:commands = luaeval('require("cord.api.command").get_commands()')
+        return filter(l:commands, 'stridx(v:val, a:ArgLead) == 0')
+    elseif len(l:args) == 2 || (len(l:args) == 3 && !l:starting_new_arg)
         let l:subcommands = luaeval('require("cord.api.command").get_subcommands(_A)', l:main_cmd)
         return filter(l:subcommands, 'stridx(v:val, a:ArgLead) == 0')
     endif

--- a/plugin/cord.vim
+++ b/plugin/cord.vim
@@ -2,7 +2,7 @@ function! CordCompleteList(ArgLead, CmdLine, CmdPos)
     let l:starting_new_arg = a:ArgLead == '' && a:CmdLine[a:CmdPos-1] =~ '\s'
     let l:args = split(a:CmdLine[:a:CmdPos-1], '\s\+')
     
-    if len(l:args) <= 1
+    if len(l:args) <= 1 || (len(l:args) == 2 && a:ArgLead != '')
         let l:commands = luaeval('require("cord.api.command").get_commands()')
         return filter(l:commands, 'stridx(v:val, a:ArgLead) == 0')
     endif
@@ -14,10 +14,7 @@ function! CordCompleteList(ArgLead, CmdLine, CmdPos)
         return filter(l:features, 'stridx(v:val, a:ArgLead) == 0')
     endif
     
-    if len(l:args) == 2 && !l:starting_new_arg
-        let l:commands = luaeval('require("cord.api.command").get_commands()')
-        return filter(l:commands, 'stridx(v:val, a:ArgLead) == 0')
-    elseif len(l:args) == 2 || (len(l:args) == 3 && !l:starting_new_arg)
+    if len(l:args) == 2 || (len(l:args) == 3 && !l:starting_new_arg)
         let l:subcommands = luaeval('require("cord.api.command").get_subcommands(_A)', l:main_cmd)
         return filter(l:subcommands, 'stridx(v:val, a:ArgLead) == 0')
     endif


### PR DESCRIPTION
This is just a quick fix to a minor annoyance I have while using cord (i.e. feel free to reject).

Allows the main command of `:Cord` to be completed from partial input. Eg. `:Cord s<Tab>` will give 'shutdown' and 'status' as options.

