### PR TITLE
Fix: Add missing configuration entry for `display.flavor` to validation rules

### DIFF
--- a/lua/cord/api/config.lua
+++ b/lua/cord/api/config.lua
@@ -16,6 +16,7 @@ local validation_rules = {
   ['display.theme'] = { 'string' },
   ['display.swap_fields'] = { 'boolean' },
   ['display.swap_icons'] = { 'boolean' },
+  ['display.flavor'] = { 'string' },  -- Added the missing entry
 
   ['timestamp'] = { 'table' },
   ['timestamp.enabled'] = { 'boolean' },


### PR DESCRIPTION
Added `display.flavor` to the validation rules to prevent "Unknown configuration entry" warning.

- Included `display.flavor` as a valid string entry in the config validation.
- Ensures that the config validation no longer triggers warnings for `display.flavor`.
