### PR TITLE
feat(mappings): add LALRPOP mapping

### DIFF
--- a/lua/cord/plugin/activity/mappings.lua
+++ b/lua/cord/plugin/activity/mappings.lua
@@ -82,6 +82,7 @@ M.filetype_mappings = {
   jsonc = { 'language', 'json', 'JSON' },
   julia = { 'language', 'julia', 'Julia' },
   kotlin = { 'language', 'kotlin', 'Kotlin' },
+  lalrpop = { 'language', 'rust', 'LALRPOP' },
   lisp = { 'language', 'lisp', 'Lisp' },
   logcheck = { 'language', 'log', 'Logcheck' },
   lua = { 'language', 'lua', 'Lua' },


### PR DESCRIPTION
## 📋 Checklist

<!-- Please check all requirements are met using [x] -->

- [X] I have read the [contribution guidelines](https://github.com/vyfor/cord.nvim/wiki/Contributing).
- [X] My PR title & commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) spec.
- [X] I have linted, formatted, and tested my changes.

## 📝 Description

As outlined in #223, we'll use the `rust` icon for this one, since
LALRPOP does not have its own icon; given that it interfaces with Rust,
it makes sense to use the Rust icon as well, so long they don't create
their own custom one.

Closes #223

Closes #232
Closes #233 

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
