### PR TITLE
build: delete `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.89.0"


### PR DESCRIPTION
## 📋 Checklist

<!-- Please check all requirements are met using [x] -->

- [x] I have read the [contribution guidelines](https://github.com/vyfor/cord.nvim/wiki/Contributing).
- [x] My PR title & commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) spec.
- [x] I have linted, formatted, and tested my changes.

## 📝 Description

<!-- Provide a clear and concise description of the changes made in this pull request -->
This PR deletes the `rust-toolchain.toml` file, as it is no longer needed after this project stopped using nightly. The reason behind this is that I want to compile the code myself instead of downloading a binary from github, and directly specifing a version makes rustup unnecessarily download a whole toolchain on my computer instead of using the existing stable one. 

An alternative to deleting this file would be to change the version to just `"stable"` — the minimum rust version is indicated by `Cargo.toml`  anyways.