### PR TITLE
docs(configuration): mark `timestamp.enabled` as currently broken

### DIFF
--- a/.github/wiki/Configuration.md
+++ b/.github/wiki/Configuration.md
@@ -185,12 +185,12 @@ With this option set to true, the plugin **will not start automatically**. Inste
 
 ## ⏰ Timestamp
 
-| Option                      | Type      | Default | Description                              |
-| --------------------------- | --------- | ------- | ---------------------------------------- |
-| `timestamp.enabled`         | `boolean` | `true`  | Show elapsed time in presence            |
-| `timestamp.reset_on_idle`   | `boolean` | `false` | Reset timestamp when entering idle state |
-| `timestamp.reset_on_change` | `boolean` | `false` | Reset timestamp when presence changes    |
-| `timestamp.shared`          | `boolean` | `false` | Synchronize timestamps between clients   |
+| Option                      | Type      | Default | Description                                                                                                                                                                                     |
+| --------------------------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `timestamp.enabled`         | `boolean` | `true`  | Show elapsed time in presence. <br /> Currently Broken. See [FAQ](https://github.com/vyfor/cord.nvim/wiki/FAQ#q-why-cant-i-disable-timestamps-in-my-rich-presence-why-are-they-misbehaving) |
+| `timestamp.reset_on_idle`   | `boolean` | `false` | Reset timestamp when entering idle state                                                                                                                                                        |
+| `timestamp.reset_on_change` | `boolean` | `false` | Reset timestamp when presence changes                                                                                                                                                           |
+| `timestamp.shared`          | `boolean` | `false` | Synchronize timestamps between clients                                                                                                                                                          |
 
 ## 💤 Idle
 

--- a/doc/cord.txt
+++ b/doc/cord.txt
@@ -1,4 +1,4 @@
-*cord.txt*            For NVIM v0.6.0           Last change: 2025 September 11
+*cord.txt*            For NVIM v0.6.0           Last change: 2025 September 14
 
 ==============================================================================
 Table of Contents                                     *cord-table-of-contents*
@@ -248,20 +248,17 @@ VIEW ~
 
 TIMESTAMP                                       *cord-configuration-timestamp*
 
-  ----------------------------------------------------------------------------------
+  ---------------------------------------------------------------------------------------------------------
   Option                      Type      Default   Description
-  --------------------------- --------- --------- ----------------------------------
-  timestamp.enabled           boolean   true      Show elapsed time in presence
+  --------------------------- --------- --------- ---------------------------------------------------------
+  timestamp.enabled           boolean   true      Show elapsed time in presence. Currently Broken. See FAQ
 
-  timestamp.reset_on_idle     boolean   false     Reset timestamp when entering idle
-                                                  state
+  timestamp.reset_on_idle     boolean   false     Reset timestamp when entering idle state
 
-  timestamp.reset_on_change   boolean   false     Reset timestamp when presence
-                                                  changes
+  timestamp.reset_on_change   boolean   false     Reset timestamp when presence changes
 
-  timestamp.shared            boolean   false     Synchronize timestamps between
-                                                  clients
-  ----------------------------------------------------------------------------------
+  timestamp.shared            boolean   false     Synchronize timestamps between clients
+  ---------------------------------------------------------------------------------------------------------
 
 IDLE                                                 *cord-configuration-idle*
 


### PR DESCRIPTION
## 📋 Checklist

- [x] I have read the [contribution guidelines](https://github.com/vyfor/cord.nvim/wiki/Contributing).
- [x] My PR title & commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) spec.
- [x] I have linted, formatted, and tested my changes.

## 📝 Description

This PR updates the documentation to indicate that the `timestamp.enabled` option should not be used at the moment.

Relevant section from the FAQ:

> It used to work as expected, but I suspect that Discord introduced a bug in recent updates. When you omit timestamps in your activity payload, the absence of a timer is expected at first. However, within seconds the timer reappears and resets to zero on every new activity update. In my testing, this reappearance has been inconsistent—sometimes happening immediately, and other times after a couple of seconds. Interestingly, during the brief period without the timer, updates go through instantly without any apparent rate limiting on the client side. This behavior appears to be due to changes in how Discord handles rich presence updates internally, rather than an issue with the plugin itself.