### PR TITLE
feat: add `:Cord reconnect` command

### DIFF
--- a/.github/wiki/Configuration.md
+++ b/.github/wiki/Configuration.md
@@ -483,6 +483,7 @@ The `advanced.cursor_update_mode` option controls how cursor position updates ar
 - `:Cord status` - Show connection status
 - `:Cord version` - Show current server version
 - `:Cord restart` - Restart the server
+- `:Cord reconnect` - Reconnect to Discord
 - `:Cord shutdown` - Disconnect from Discord and shutdown the server
 - `:Cord health` - Validate user configuration
 

--- a/lua/cord/api/command.lua
+++ b/lua/cord/api/command.lua
@@ -92,6 +92,26 @@ M.restart = function()
     cord.tx:restart()
   end)
 end
+M.reconnect = function()
+  vim.schedule(function()
+    local cord = require 'cord.server'
+    if cord.is_updating then
+      require('cord.api.log').notify('Operation cancelled: Server is updating', vim.log.levels.WARN)
+      return
+    end
+
+    require('cord.api.log').debug 'Reconnecting...'
+    local function initialize()
+      require('cord.core.async').run(function() cord:initialize() end)
+    end
+
+    if not cord.tx then return initialize() end
+    if not cord.client then return initialize() end
+    if cord.client:is_closing() then return initialize() end
+
+    cord.tx:reconnect()
+  end)
+end
 M.shutdown = function()
   local cord = require 'cord.server'
 
@@ -208,6 +228,7 @@ M.commands = {
   status = M.status,
   version = M.version,
   restart = M.restart,
+  reconnect = M.reconnect,
   shutdown = M.shutdown,
   health = M.health,
 }

--- a/lua/cord/server/init.lua
+++ b/lua/cord/server/init.lua
@@ -99,6 +99,7 @@ function M:run()
             M.manager = manager
           end)
         elseif data.status == 'disconnected' then
+          local was_connected = self.status == 'ready' or self.status == 'connected'
           self.status = 'initialized'
 
           if M.manager then M.manager:cleanup() end
@@ -110,7 +111,7 @@ function M:run()
             )
           end
 
-          if config.advanced.discord.reconnect.enabled then logger.info 'Reconnecting...' end
+          if was_connected and config.advanced.discord.reconnect.enabled then logger.info 'Reconnecting...' end
         end
       end)
     )

--- a/lua/cord/server/ipc/sender.lua
+++ b/lua/cord/server/ipc/sender.lua
@@ -51,4 +51,6 @@ function Producer:shutdown() self:send_event 'shutdown' end
 
 function Producer:restart() self:send_event 'restart' end
 
+function Producer:reconnect() self:send_event 'reconnect' end
+
 return Producer

--- a/src/cord.rs
+++ b/src/cord.rs
@@ -11,6 +11,7 @@ use crate::messages::events::server::{LogEvent, ServerEvent};
 use crate::messages::message::Message;
 use crate::presence::manager::ActivityManager;
 use crate::protocol::msgpack::Serialize;
+use crate::types::reconnect::ReconnectState;
 use crate::session::SessionManager;
 use crate::util::lockfile::ServerLock;
 use crate::util::logger::{self, LOGGER, LogLevel, Logger};
@@ -35,6 +36,7 @@ pub struct Cord {
     pub tx: Sender<Message>,
     pub rx: Receiver<Message>,
     pub log_buffer: VecDeque<LogEvent>,
+    pub reconnect_state: ReconnectState,
     _lock: ServerLock,
 }
 
@@ -63,6 +65,7 @@ impl Cord {
             tx,
             rx,
             log_buffer: VecDeque::with_capacity(100),
+            reconnect_state: ReconnectState::default(),
             _lock: lock,
         })
     }
@@ -126,6 +129,8 @@ impl Cord {
 
     /// Cleans up before shutdown.
     pub fn cleanup(&mut self) {
+        self.reconnect_state.cancel();
+
         if let Ok(mut client) = self.activity_manager.client.write() {
             client.close();
         }

--- a/src/ipc/discord/client.rs
+++ b/src/ipc/discord/client.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::Sender;
 use std::thread::JoinHandle;
-use std::time::Duration;
 
 use crate::ipc::discord::error::DiscordError;
 use crate::messages::events::server::status_update::Status;
@@ -134,39 +133,6 @@ impl RichClient {
             Err(_) => Err("The connection to Discord was lost".into()),
             _ => Ok(()),
         }
-    }
-
-    /// Reconnects to Discord with exponential backoff.
-    pub fn reconnect(&mut self, interval: u64, tx: Sender<Message>) {
-        debug!(
-            "Initiating reconnection to Discord with interval={}ms",
-            interval
-        );
-        self.is_reconnecting = true;
-        self.close();
-
-        std::thread::sleep(Duration::from_millis(500));
-
-        let mut client = Self::new(self.client_id, self.pipe_paths.clone());
-        while self.is_reconnecting {
-            trace!("Attempting to reconnect to Discord");
-            if client.connect().is_ok() {
-                if client.handshake().is_ok() {
-                    debug!("Successfully reconnected to Discord");
-                    *self = client;
-                    let _ = self.start_read_thread(tx);
-
-                    break;
-                } else {
-                    trace!("Handshake failed during reconnection");
-                    client.close();
-                }
-            };
-
-            std::thread::sleep(Duration::from_millis(interval));
-        }
-
-        self.is_reconnecting = false;
     }
 }
 

--- a/src/messages/events/client/initialize.rs
+++ b/src/messages/events/client/initialize.rs
@@ -5,11 +5,13 @@ use crate::error::CordErrorKind;
 use crate::ipc::discord::client::Connection;
 use crate::ipc::pipe::PipeServerImpl;
 use crate::messages::events::event::{EventContext, OnEvent};
+use crate::messages::events::local::ReconnectEvent;
 use crate::messages::events::server::StatusUpdateEvent;
 use crate::messages::events::server::status_update::Status;
 use crate::protocol::msgpack::MsgPack;
 use crate::types::config::PluginConfig;
 use crate::util::{logger, now};
+use crate::local_event;
 
 #[derive(Debug)]
 pub struct InitializeEvent {
@@ -67,15 +69,11 @@ impl OnEvent for InitializeEvent {
                         ctx.client_id,
                         "Connection failed, scheduling reconnect"
                     );
-                    drop(client);
-                    let client_clone = rich_client.clone();
-                    let tx = ctx.cord.tx.clone();
-
-                    let reconnect_interval = config.reconnect_interval;
-                    std::thread::spawn(move || {
-                        let mut client = client_clone.write().unwrap();
-                        client.reconnect(reconnect_interval, tx.clone());
-                    });
+                    let _ = ctx.cord.tx.send(local_event!(
+                        0,
+                        Reconnect,
+                        ReconnectEvent::new(false)
+                    ));
                 } else {
                     debug!(
                         ctx.client_id,

--- a/src/messages/events/client/mod.rs
+++ b/src/messages/events/client/mod.rs
@@ -9,6 +9,7 @@ pub mod clear_activity;
 pub mod connect;
 pub mod disconnect;
 pub mod initialize;
+pub mod reconnect;
 pub mod restart;
 pub mod shutdown;
 pub mod update_activity;
@@ -17,6 +18,7 @@ pub use clear_activity::ClearActivityEvent;
 pub use connect::ConnectEvent;
 pub use disconnect::DisconnectEvent;
 pub use initialize::InitializeEvent;
+pub use reconnect::ReconnectClientEvent;
 pub use restart::RestartEvent;
 pub use shutdown::ShutdownEvent;
 pub use update_activity::UpdateActivityEvent;
@@ -30,6 +32,7 @@ pub enum ClientEvent {
     Disconnect(DisconnectEvent),
     Shutdown(ShutdownEvent),
     Restart(RestartEvent),
+    Reconnect(ReconnectClientEvent),
 }
 
 /// Extracts the 'data' field from a map and returns an error if it is missing or invalid.
@@ -75,6 +78,7 @@ impl ClientEvent {
             "disconnect" => Self::Disconnect(DisconnectEvent),
             "shutdown" => Self::Shutdown(ShutdownEvent),
             "restart" => Self::Restart(RestartEvent),
+            "reconnect" => Self::Reconnect(ReconnectClientEvent),
             _ => return Err(format!("Unknown message type: {}", ty).into()),
         })
     }
@@ -91,6 +95,7 @@ impl OnEvent for ClientEvent {
             Self::ClearActivity(e) => e.on_event(ctx),
             Self::Shutdown(e) => e.on_event(ctx),
             Self::Restart(e) => e.on_event(ctx),
+            Self::Reconnect(e) => e.on_event(ctx),
         }
     }
 }

--- a/src/messages/events/client/reconnect.rs
+++ b/src/messages/events/client/reconnect.rs
@@ -1,0 +1,19 @@
+use crate::messages::events::event::{EventContext, OnEvent};
+use crate::messages::events::local::ReconnectEvent;
+use crate::{debug, local_event};
+
+#[derive(Debug, Default)]
+pub struct ReconnectClientEvent;
+
+impl OnEvent for ReconnectClientEvent {
+    fn on_event(self, ctx: &mut EventContext) -> crate::Result<()> {
+        debug!(ctx.client_id, "Processing reconnect client event");
+
+        let _ = ctx
+            .cord
+            .tx
+            .send(local_event!(ctx.client_id, Reconnect, ReconnectEvent::new(true)));
+
+        Ok(())
+    }
+}

--- a/src/messages/events/local/error.rs
+++ b/src/messages/events/local/error.rs
@@ -34,10 +34,6 @@ impl OnEvent for ErrorEvent {
                         return Err("Discord closed the connection".into());
                     }
 
-                    ctx.cord.pipe.broadcast(&MsgPack::serialize(
-                        &StatusUpdateEvent::disconnected(),
-                    )?)?;
-
                     let _ = ctx
                         .cord
                         .tx

--- a/src/messages/events/local/error.rs
+++ b/src/messages/events/local/error.rs
@@ -1,9 +1,10 @@
 use crate::ipc::discord::error::DiscordError;
 use crate::ipc::pipe::PipeServerImpl;
 use crate::messages::events::event::{EventContext, OnEvent};
+use crate::messages::events::local::ReconnectEvent;
 use crate::messages::events::server::StatusUpdateEvent;
 use crate::protocol::msgpack::MsgPack;
-use crate::{debug, error};
+use crate::{debug, error, local_event};
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 
@@ -37,14 +38,10 @@ impl OnEvent for ErrorEvent {
                         &StatusUpdateEvent::disconnected(),
                     )?)?;
 
-                    let rich_client = ctx.cord.activity_manager.client.clone();
-                    let tx = ctx.cord.tx.clone();
-                    std::thread::spawn(move || {
-                        rich_client
-                            .write()
-                            .unwrap()
-                            .reconnect(reconnect_interval, tx);
-                    });
+                    let _ = ctx
+                        .cord
+                        .tx
+                        .send(local_event!(0, Reconnect, ReconnectEvent::new(false)));
 
                     debug!("Discord closed the connection");
 

--- a/src/messages/events/local/mod.rs
+++ b/src/messages/events/local/mod.rs
@@ -1,6 +1,10 @@
 pub mod error;
+pub mod reconnect;
+pub mod reconnect_complete;
 
 pub use error::ErrorEvent;
+pub use reconnect::ReconnectEvent;
+pub use reconnect_complete::ReconnectCompleteEvent;
 
 use crate::trace;
 use super::event::{EventContext, OnEvent};
@@ -8,6 +12,8 @@ use super::event::{EventContext, OnEvent};
 #[derive(Debug)]
 pub enum LocalEvent {
     Error(ErrorEvent),
+    Reconnect(ReconnectEvent),
+    ReconnectComplete(ReconnectCompleteEvent),
 }
 
 impl OnEvent for LocalEvent {
@@ -15,6 +21,17 @@ impl OnEvent for LocalEvent {
         match self {
             Self::Error(e) => {
                 trace!(ctx.client_id, "Dispatching local error event");
+                e.on_event(ctx)
+            }
+            Self::Reconnect(e) => {
+                trace!(ctx.client_id, "Dispatching local reconnect event");
+                e.on_event(ctx)
+            }
+            Self::ReconnectComplete(e) => {
+                trace!(
+                    ctx.client_id,
+                    "Dispatching local reconnect complete event"
+                );
                 e.on_event(ctx)
             }
         }

--- a/src/messages/events/local/reconnect.rs
+++ b/src/messages/events/local/reconnect.rs
@@ -64,7 +64,10 @@ impl OnEvent for ReconnectEvent {
             client.is_reconnecting = true;
             client.close();
 
+            std::thread::sleep(Duration::from_millis(500));
+
             let mut result = Ok(());
+            let mut first = true;
             loop {
                 if cancel.load(Ordering::SeqCst) {
                     debug!(client_id, "Reconnect loop cancelled");
@@ -72,7 +75,11 @@ impl OnEvent for ReconnectEvent {
                     break;
                 }
 
-                std::thread::sleep(Duration::from_millis(500));
+                if first {
+                    first = false;
+                } else if !manual && interval > 0 {
+                    std::thread::sleep(Duration::from_millis(interval));
+                }
 
                 let mut rich_client =
                     crate::ipc::discord::client::RichClient::new(
@@ -92,9 +99,6 @@ impl OnEvent for ReconnectEvent {
                                 );
                                 rich_client.close();
                                 if !manual && interval > 0 {
-                                    std::thread::sleep(Duration::from_millis(
-                                        interval,
-                                    ));
                                     continue;
                                 }
                                 result = Err(e);
@@ -108,9 +112,6 @@ impl OnEvent for ReconnectEvent {
                             debug!(client_id, "Reconnect: handshake failed: {}", e);
                             rich_client.close();
                             if !manual && interval > 0 {
-                                std::thread::sleep(Duration::from_millis(
-                                    interval,
-                                ));
                                 continue;
                             }
                             result = Err(e);
@@ -120,7 +121,6 @@ impl OnEvent for ReconnectEvent {
                     Err(e) => {
                         debug!(client_id, "Reconnect: connect failed: {}", e);
                         if !manual && interval > 0 {
-                            std::thread::sleep(Duration::from_millis(interval));
                             continue;
                         }
                         result = Err(e);

--- a/src/messages/events/local/reconnect.rs
+++ b/src/messages/events/local/reconnect.rs
@@ -1,0 +1,142 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use crate::ipc::discord::client::Connection;
+use crate::ipc::pipe::PipeServerImpl;
+use crate::messages::events::event::{EventContext, OnEvent};
+use crate::messages::events::server::StatusUpdateEvent;
+use crate::messages::events::local::ReconnectCompleteEvent;
+use crate::protocol::msgpack::MsgPack;
+use crate::{debug, local_event, trace};
+
+#[derive(Debug)]
+pub struct ReconnectEvent {
+    pub manual: bool,
+}
+
+impl ReconnectEvent {
+    pub fn new(manual: bool) -> Self {
+        Self { manual }
+    }
+}
+
+impl OnEvent for ReconnectEvent {
+    fn on_event(self, ctx: &mut EventContext) -> crate::Result<()> {
+        let client_id = ctx.client_id;
+
+        if ctx.cord.reconnect_state.in_progress {
+            if self.manual {
+                debug!(
+                    client_id,
+                    "Cancelling in-flight reconnect request and restarting"
+                );
+                ctx.cord.reconnect_state.cancel();
+            } else {
+                trace!(
+                    client_id,
+                    "Dropping reconnect request as another one is already in progress"
+                );
+                return Ok(());
+            }
+        }
+
+        let rich_client = ctx.cord.activity_manager.client.clone();
+        let cancel = Arc::new(AtomicBool::new(false));
+        ctx.cord.reconnect_state.in_progress = true;
+        ctx.cord.reconnect_state.cancel = Some(cancel.clone());
+
+        ctx.cord.pipe.broadcast(&MsgPack::serialize(
+            &StatusUpdateEvent::disconnected(),
+        )?)?;
+        ctx.cord.pipe.broadcast(&MsgPack::serialize(
+            &StatusUpdateEvent::connecting(),
+        )?)?;
+
+        let interval = ctx.cord.config.reconnect_interval;
+        let tx = ctx.cord.tx.clone();
+        let manual = self.manual;
+
+        debug!(client_id, "Spawning reconnect worker (manual={})", manual);
+
+        std::thread::spawn(move || {
+            let mut client = rich_client.write().unwrap();
+            client.is_reconnecting = true;
+            client.close();
+
+            let mut result = Ok(());
+            loop {
+                if cancel.load(Ordering::SeqCst) {
+                    debug!(client_id, "Reconnect loop cancelled");
+                    result = Err("Reconnect cancelled".into());
+                    break;
+                }
+
+                std::thread::sleep(Duration::from_millis(500));
+
+                let mut rich_client =
+                    crate::ipc::discord::client::RichClient::new(
+                        client.client_id,
+                        client.pipe_paths.clone(),
+                    );
+
+                match rich_client.connect() {
+                    Ok(()) => match rich_client.handshake() {
+                        Ok(()) => {
+                            if let Err(e) =
+                                rich_client.start_read_thread(tx.clone())
+                            {
+                                debug!(
+                                    client_id,
+                                    "Reconnect: start_read_thread failed: {}", e
+                                );
+                                rich_client.close();
+                                if !manual && interval > 0 {
+                                    std::thread::sleep(Duration::from_millis(
+                                        interval,
+                                    ));
+                                    continue;
+                                }
+                                result = Err(e);
+                                break;
+                            }
+                            debug!(client_id, "Reconnected to Discord");
+                            *client = rich_client;
+                            break;
+                        }
+                        Err(e) => {
+                            debug!(client_id, "Reconnect: handshake failed: {}", e);
+                            rich_client.close();
+                            if !manual && interval > 0 {
+                                std::thread::sleep(Duration::from_millis(
+                                    interval,
+                                ));
+                                continue;
+                            }
+                            result = Err(e);
+                            break;
+                        }
+                    },
+                    Err(e) => {
+                        debug!(client_id, "Reconnect: connect failed: {}", e);
+                        if !manual && interval > 0 {
+                            std::thread::sleep(Duration::from_millis(interval));
+                            continue;
+                        }
+                        result = Err(e);
+                        break;
+                    }
+                }
+            }
+
+            client.is_reconnecting = false;
+            let _ = tx.send(local_event!(
+                client_id,
+                ReconnectComplete,
+                ReconnectCompleteEvent::new(manual, result.into())
+            ));
+        });
+
+        Ok(())
+    }
+}

--- a/src/messages/events/local/reconnect_complete.rs
+++ b/src/messages/events/local/reconnect_complete.rs
@@ -1,0 +1,57 @@
+use crate::ipc::pipe::PipeServerImpl;
+use crate::messages::events::event::{EventContext, OnEvent};
+use crate::messages::events::server::StatusUpdateEvent;
+use crate::protocol::msgpack::MsgPack;
+use crate::{debug, error};
+
+#[derive(Debug)]
+pub enum ReconnectStatus {
+    Ok,
+    Err(String),
+}
+
+impl From<crate::Result<()>> for ReconnectStatus {
+    fn from(result: crate::Result<()>) -> Self {
+        match result {
+            Ok(()) => Self::Ok,
+            Err(err) => Self::Err(err.to_string()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ReconnectCompleteEvent {
+    pub manual: bool,
+    pub status: ReconnectStatus,
+}
+
+impl ReconnectCompleteEvent {
+    pub fn new(manual: bool, status: ReconnectStatus) -> Self {
+        Self { manual, status }
+    }
+}
+
+impl OnEvent for ReconnectCompleteEvent {
+    fn on_event(self, ctx: &mut EventContext) -> crate::Result<()> {
+        let client_id = ctx.client_id;
+        ctx.cord.reconnect_state.in_progress = false;
+        ctx.cord.reconnect_state.cancel = None;
+
+        match &self.status {
+            ReconnectStatus::Ok => {
+                debug!(client_id, "Reconnect successful");
+            }
+            ReconnectStatus::Err(err) => {
+                debug!(client_id, "Reconnect failed: {}", err);
+                ctx.cord.pipe.broadcast(&MsgPack::serialize(
+                    &StatusUpdateEvent::disconnected(),
+                )?)?;
+                if self.manual {
+                    error!(client_id, "Failed to reconnect to Discord: {}", err);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,1 +1,2 @@
 pub mod config;
+pub mod reconnect;

--- a/src/types/reconnect.rs
+++ b/src/types/reconnect.rs
@@ -1,0 +1,17 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[derive(Default)]
+pub struct ReconnectState {
+    pub in_progress: bool,
+    pub cancel: Option<Arc<AtomicBool>>,
+}
+
+impl ReconnectState {
+    pub fn cancel(&mut self) {
+        if let Some(cancel) = self.cancel.take() {
+            cancel.store(true, Ordering::SeqCst);
+        }
+        self.in_progress = false;
+    }
+}


### PR DESCRIPTION
closes #360

- **refactor: rework reconnection logic (#361)**
- **feat: add `:Cord reconnect` command (#362)**
- **fix: remove duplicate reconnection attempts**
- **fix: suppress redundant logging**
